### PR TITLE
Add uv launch instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ To install **StoryCraftr**, run the following command:
 pipx install git+https://github.com/raestrada/storycraftr.git@v0.9.1-beta2
 ```
 
+Alternatively, if you have `uv` and `uvx` installed on your system, you can run storycraftr without installing it first:
+
+```bash
+uvx --from git+https://github.com/raestrada/storycraftr.git@v0.9.1-beta2 storycraftr
+```
+
 ### Important: Before using StoryCraftr, make sure to set your OpenAI API key:
 
 Store the key in a text file located at `~/.storycraftr/openai_api_key.txt` for convenience.


### PR DESCRIPTION
Many in the python community are starting to converge on the use of `uv` to replace `conda`, `pyenv`, `virtualenvwrapper` etc.